### PR TITLE
Add postgres as database engine

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -4,7 +4,7 @@
   gather_facts: no
 
   vars:
-    dbname: vagrant
+    dbname: dev
     dbuser: vagrant
     dbpassword: vagrant
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 Django==1.8.5
 Markdown==2.6.5
 Paver==1.2.4
+dj-database-url==0.4.0
 django-filter==0.11.0
 djangorestframework==3.3.1
 factory-boy==2.6.1
 fake-factory==0.5.3
+psycopg2==2.6.1
 uWSGI==2.0.12

--- a/webservice/config/settings.py
+++ b/webservice/config/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -77,10 +78,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    'default': dj_database_url.config()
 }
 
 # Internationalization


### PR DESCRIPTION
Pra isso funcionar localmente, basta seguir os seguintes passos:

1. vagrant provision && vagrant ssh

2. echo DATABASE_URL=postgres://vagrant:vagrant@localhost:5432/dev >> ~/.pam_environment

3. Saia da máquina vagrant e acesse ela novamente com vagrant ssh

4. paver migratedb